### PR TITLE
fix UTC conversion

### DIFF
--- a/src/client/app.js
+++ b/src/client/app.js
@@ -452,16 +452,20 @@ function showScheduledResults() {
     `;
     
     const scheduledDate = new Date(currentScheduler.scheduled_time);
+    const schedulerTimezone = currentScheduler.timezone || 'UTC';
+    
     const formattedDate = scheduledDate.toLocaleDateString('en-US', { 
         weekday: 'long', 
         year: 'numeric', 
         month: 'long', 
-        day: 'numeric' 
+        day: 'numeric',
+        timeZone: schedulerTimezone
     });
     const formattedTime = scheduledDate.toLocaleTimeString('en-US', { 
         hour: 'numeric', 
         minute: '2-digit',
-        timeZoneName: 'short'
+        timeZoneName: 'short',
+        timeZone: schedulerTimezone
     });
     
     scheduledTimeDiv.innerHTML = `
@@ -967,19 +971,8 @@ function showSuggestedTimes(suggestedTimes) {
 // Show the scheduled time to the user
 // Show detailed schedule information
 async function showDetailedSchedule(scheduleData) {
-    // Get candidate's timezone for display
-    let candidateTimezone = 'UTC';
-    try {
-        const users = await fetch(`${API_BASE}/scheduler/${currentScheduler.id}/users`).then(r => r.json());
-        if (users.success && users.users) {
-            const candidate = users.users.find(u => u.role === 'candidate');
-            if (candidate && candidate.timezone) {
-                candidateTimezone = candidate.timezone;
-            }
-        }
-    } catch (error) {
-        console.error('Error fetching candidate timezone:', error);
-    }
+    // Use the scheduler's timezone for display
+    const schedulerTimezone = currentScheduler.timezone || 'UTC';
     
     const scheduledDate = new Date(scheduleData.scheduled_time);
     const formattedDate = scheduledDate.toLocaleDateString('en-US', { 
@@ -987,13 +980,13 @@ async function showDetailedSchedule(scheduleData) {
         year: 'numeric', 
         month: 'long', 
         day: 'numeric',
-        timeZone: candidateTimezone
+        timeZone: schedulerTimezone
     });
     const formattedTime = scheduledDate.toLocaleTimeString('en-US', { 
         hour: '2-digit', 
         minute: '2-digit',
         timeZoneName: 'short',
-        timeZone: candidateTimezone
+        timeZone: schedulerTimezone
     });
 
     const scheduledTimeDiv = document.createElement('div');
@@ -1027,24 +1020,24 @@ async function showDetailedSchedule(scheduleData) {
         `;
 
         scheduleData.individual_interviews.forEach((interview) => {
-            // Convert interview time to candidate's timezone
+            // Convert interview time to scheduler's timezone
             const interviewDateTime = new Date(`${interview.date}T${interview.start_time}:00Z`);
             const date = interviewDateTime.toLocaleDateString('en-US', { 
                 weekday: 'short', 
                 month: 'short', 
                 day: 'numeric',
-                timeZone: candidateTimezone
+                timeZone: schedulerTimezone
             });
             const startTime = interviewDateTime.toLocaleTimeString('en-US', { 
                 hour: '2-digit', 
                 minute: '2-digit',
-                timeZone: candidateTimezone
+                timeZone: schedulerTimezone
             });
             const endDateTime = new Date(`${interview.date}T${interview.end_time}:00Z`);
             const endTime = endDateTime.toLocaleTimeString('en-US', { 
                 hour: '2-digit', 
                 minute: '2-digit',
-                timeZone: candidateTimezone
+                timeZone: schedulerTimezone
             });
             const time = `${date} ${startTime} - ${endTime}`;
             

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -43,6 +43,18 @@ let currentUser = null;
 let currentAvailability = [];
 let currentTimezone = 'UTC';
 
+// Auto-detect user's timezone
+function detectUserTimezone() {
+  try {
+    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    console.log('🌍 Auto-detected timezone:', detected);
+    return detected;
+  } catch (error) {
+    console.log('⚠️ Could not detect timezone, using UTC');
+    return 'UTC';
+  }
+}
+
 // API base URL
 const API_BASE = '/api';
 
@@ -468,11 +480,23 @@ function showScheduledResults() {
         timeZone: schedulerTimezone
     });
     
+    // Also show in user's local timezone if different
+    let localTimeDisplay = '';
+    if (schedulerTimezone !== currentTimezone) {
+        const localFormattedTime = scheduledDate.toLocaleTimeString('en-US', { 
+            hour: 'numeric', 
+            minute: '2-digit',
+            timeZoneName: 'short',
+            timeZone: currentTimezone
+        });
+        localTimeDisplay = `<br><small style="color: var(--muted);">Your local time: ${localFormattedTime}</small>`;
+    }
+    
     scheduledTimeDiv.innerHTML = `
         <div style="text-align: center;">
             <h3 style="color: var(--success); margin-bottom: 10px;">🎉 Interview Scheduled!</h3>
             <p style="font-size: 1.1rem; margin-bottom: 5px;"><strong>${formattedDate}</strong></p>
-            <p style="font-size: 1rem; color: var(--text-secondary);">${formattedTime}</p>
+            <p style="font-size: 1rem; color: var(--text-secondary);">${formattedTime}${localTimeDisplay}</p>
             <p style="margin-top: 15px; color: var(--text-secondary);">Check your email for detailed information.</p>
         </div>
     `;
@@ -998,6 +1022,9 @@ async function showDetailedSchedule(scheduleData) {
             <h3 style="color: var(--primary); margin-bottom: 10px;">${formattedDate}</h3>
             <p style="font-size: 1.2rem; color: var(--text-dark);">${formattedTime}</p>
             <p style="color: var(--muted); margin-top: 10px;">${scheduleData.message || 'Confirmation emails have been sent to all participants.'}</p>
+            <p style="color: var(--muted); font-size: 0.9rem; margin-top: 10px;">
+                📍 All times shown in ${schedulerTimezone} timezone
+            </p>
         </div>
     `;
 
@@ -1221,42 +1248,23 @@ function updateAvailabilityDisplay() {
                             return s;
                         }
                         
-                        // Use the same timezone conversion logic as the calendar
-                        const timezoneOffsets = {
-                            'UTC': 0,
-                            'America/New_York': -4, // EDT (summer)
-                            'America/Chicago': -5,  // CDT
-                            'America/Denver': -6,   // MDT
-                            'America/Los_Angeles': -7, // PDT (summer)
-                            'Europe/London': 1,     // BST (summer)
-                            'Europe/Paris': 2,      // CEST (summer)
-                            'Asia/Tokyo': 9,
-                            'Asia/Shanghai': 8,
-                            'Australia/Sydney': 10  // AEST (winter)
-                        };
+                        // Use more accurate timezone conversion with date-fns-tz
+                        const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+                        const dateTimeString = `${today}T${s}:00`;
                         
-                        const [hours, minutes] = s.split(':').map(Number);
-                        const schedulerOffset = timezoneOffsets[schedulerTimezone] || 0;
-                        const currentOffset = timezoneOffsets[currentTimezone] || 0;
+                        // Create a date in the scheduler's timezone
+                        const zonedTime = new Date(dateTimeString + (schedulerTimezone === 'UTC' ? 'Z' : ''));
                         
-                        // Calculate the time difference
-                        const offsetDiff = currentOffset - schedulerOffset;
+                        // Convert to user's timezone
+                        const convertedTime = zonedTime.toLocaleTimeString('en-US', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            hour12: false,
+                            timeZone: currentTimezone
+                        });
                         
-                        // Apply the offset
-                        let newHours = hours + offsetDiff;
-                        let newMinutes = minutes;
-                        
-                        // Handle day overflow/underflow
-                        if (newHours < 0) {
-                            newHours += 24;
-                        } else if (newHours >= 24) {
-                            newHours -= 24;
-                        }
-                        
-                        const result = `${String(newHours).padStart(2, '0')}:${String(newMinutes).padStart(2, '0')}`;
-                        
-                        console.log(`[formatSlotForDisplay] Converting ${s} from ${schedulerTimezone} to ${currentTimezone}: ${result}`);
-                        return result;
+                        console.log(`[formatSlotForDisplay] Converting ${s} from ${schedulerTimezone} to ${currentTimezone}: ${convertedTime}`);
+                        return convertedTime;
                     } catch (e) {
                         console.error('[formatSlotForDisplay] Error converting time:', e);
                         return s;
@@ -1574,4 +1582,16 @@ document.addEventListener('DOMContentLoaded', function() {
     if (selectedDateElement) {
         selectedDateElement.value = formatDate(new Date());
     }
+    
+    // Auto-detect and set timezone
+    const detectedTimezone = detectUserTimezone();
+    currentTimezone = detectedTimezone;
+    
+    // Set timezone selector to detected timezone
+    const timezoneSelects = document.querySelectorAll('#timezoneSelect');
+    timezoneSelects.forEach(select => {
+        select.value = detectedTimezone;
+    });
+    
+    console.log('🌍 Initialized with timezone:', detectedTimezone);
 });

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -497,19 +497,7 @@ async function checkUserRegistration() {
             document.getElementById('userName').value = currentUser.name;
             document.getElementById('userRole').value = currentUser.role;
             
-            // Store user's timezone and set timezone selector
-            if (currentUser.timezone) {
-                currentTimezone = currentUser.timezone;
-                console.log('[checkUserRegistration] Setting timezone to:', currentUser.timezone);
-                // Set timezone selector if it exists
-                const timezoneSelect = document.getElementById('timezoneSelect');
-                if (timezoneSelect) {
-                    timezoneSelect.value = currentUser.timezone;
-                    console.log('[checkUserRegistration] Timezone selector set to:', timezoneSelect.value);
-                } else {
-                    console.log('[checkUserRegistration] Timezone selector not found');
-                }
-            }
+            // Timezone will be set when user submits availability
 
             // Normalize this user's availability first
             const userAvailability = Array.isArray(data.availability) ? data.availability : [];

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -590,6 +590,17 @@
         </div>
     </div>
 
+    <!-- Footer with Issues Link -->
+    <footer style="text-align: center; padding: 20px; margin-top: 40px; border-top: 1px solid var(--border); color: var(--muted);">
+        <p>
+            Found a bug or have a suggestion? 
+            <a href="https://github.com/Yang-YZ/IntervuAI/issues" target="_blank" rel="noopener noreferrer" 
+               style="color: var(--primary); text-decoration: none; font-weight: 500;">
+                Report an issue
+            </a>
+        </p>
+    </footer>
+
     <script src="app.js"></script>
 </body>
 </html>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -525,6 +525,24 @@
                 <div id="availabilityForm" class="availability-form hidden">
                     <h3>Add Your Availability</h3>
                     
+                    <!-- Timezone Selection -->
+                    <div class="form-group">
+                        <label for="timezoneSelect">Your Timezone:</label>
+                        <select id="timezoneSelect">
+                            <option value="UTC">UTC</option>
+                            <option value="America/New_York">Eastern Time (ET)</option>
+                            <option value="America/Chicago">Central Time (CT)</option>
+                            <option value="America/Denver">Mountain Time (MT)</option>
+                            <option value="America/Los_Angeles">Pacific Time (PT)</option>
+                            <option value="Europe/London">London (GMT/BST)</option>
+                            <option value="Europe/Paris">Paris (CET/CEST)</option>
+                            <option value="Asia/Tokyo">Tokyo (JST)</option>
+                            <option value="Asia/Shanghai">Shanghai (CST)</option>
+                            <option value="Australia/Sydney">Sydney (AEST/AEDT)</option>
+                        </select>
+                        <small style="color: var(--muted); font-size: 0.9rem;">Select your timezone to ensure times are displayed and saved correctly.</small>
+                    </div>
+                    
                     <!-- Date Selection -->
                     <div class="form-group">
                         <label>Select Date:</label>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -492,21 +492,6 @@
                         <strong>Scheduler ID:</strong> <span id="schedulerIdValue"></span>
                     </div>
                 </div>
-                <div class="timezone-selector">
-                    <label for="timezoneSelect">Timezone:</label>
-                    <select id="timezoneSelect">
-                        <option value="UTC">UTC</option>
-                        <option value="America/New_York">Eastern Time</option>
-                        <option value="America/Chicago">Central Time</option>
-                        <option value="America/Denver">Mountain Time</option>
-                        <option value="America/Los_Angeles">Pacific Time</option>
-                        <option value="Europe/London">London</option>
-                        <option value="Europe/Paris">Paris</option>
-                        <option value="Asia/Tokyo">Tokyo</option>
-                        <option value="Asia/Shanghai">Shanghai</option>
-                        <option value="Australia/Sydney">Sydney</option>
-                    </select>
-                </div>
             </div>
 
             <div id="statusMessage"></div>

--- a/src/server/routes/scheduler.ts
+++ b/src/server/routes/scheduler.ts
@@ -8,7 +8,6 @@ const router = express.Router();
 
 
 function getLatestAvailabilityPerUser(availabilityRecords: any[]): any[] {
-  console.log(`[getLatestAvailabilityPerUser] Input records:`, availabilityRecords.length);
   if (!availabilityRecords || availabilityRecords.length === 0) {
     return [];
   }
@@ -23,12 +22,8 @@ function getLatestAvailabilityPerUser(availabilityRecords: any[]): any[] {
     }
   });
   
-  console.log(`[getLatestAvailabilityPerUser] Latest records per user:`, userLatestMap.size);
-  
   // Return the latest records directly (new Availability format)
-  const result = Array.from(userLatestMap.values());
-  console.log(`[getLatestAvailabilityPerUser] Result:`, result.length);
-  return result;
+  return Array.from(userLatestMap.values());
 }
 
 // Create a new scheduler
@@ -260,7 +255,6 @@ router.post('/:id/generate-schedule', [
     const interviewerAvailability = getLatestAvailabilityPerUser(availability.filter((a: any) => 
       interviewers.some((interviewer: any) => interviewer.id === a.user_id)
     ));
-
 
     if (candidateAvailability.length === 0 || interviewerAvailability.length === 0) {
       res.status(400).json({ 
@@ -562,8 +556,6 @@ router.get('/:id/status', [
 
     // Format availability details for display
     const formatAvailabilityDetails = (availability: any[], userTimezone?: string) => {
-      console.log(`[formatAvailabilityDetails] Called with userTimezone:`, userTimezone);
-      
       // Group time slots by date since each slot has its own date
       const dateMap = new Map<string, string[]>();
       
@@ -578,10 +570,8 @@ router.get('/:id/status', [
           let formattedSlot;
           if (slot.start && slot.start.includes('T')) {
             const displayTimezone = userTimezone || scheduler.timezone || 'UTC';
-            console.log(`[formatAvailabilityDetails] Converting slot: ${slot.start} -> ${slot.end} from UTC to ${displayTimezone}`);
             const startTime = format(utcToZonedTime(slot.start, displayTimezone), 'HH:mm', { timeZone: displayTimezone });
             const endTime = format(utcToZonedTime(slot.end, displayTimezone), 'HH:mm', { timeZone: displayTimezone });
-            console.log(`[formatAvailabilityDetails] Converted to: ${startTime} -> ${endTime}`);
             formattedSlot = `${startTime}-${endTime}`;
           } else {
             formattedSlot = `${slot.start}-${slot.end}`;
@@ -592,16 +582,11 @@ router.get('/:id/status', [
       });
       
       // Convert map to array format
-      const result = Array.from(dateMap.entries()).map(([date, timeSlots]) => {
-        console.log(`[formatAvailabilityDetails] Date: ${date}, TimeSlots: ${timeSlots.join(', ')}`);
-        return {
-          date: date,
-          timeSlots: timeSlots.join(', '),
-          slotCount: timeSlots.length
-        };
-      });
-      
-      return result;
+      return Array.from(dateMap.entries()).map(([date, timeSlots]) => ({
+        date: date,
+        timeSlots: timeSlots.join(', '),
+        slotCount: timeSlots.length
+      }));
     };
 
     res.json({

--- a/src/server/services/schedulerService.ts
+++ b/src/server/services/schedulerService.ts
@@ -189,7 +189,6 @@ export class SchedulerService {
         );
         
         // Try to find a slot that doesn't conflict with already scheduled interviews
-        let foundNonConflictingSlot = false;
         for (const slot of overlappingSlots) {
           const proposedSlot = {
             date: slot.date,
@@ -218,7 +217,9 @@ export class SchedulerService {
           });
           
           if (!conflictsWithScheduled) {
-            // Found a non-conflicting slot
+            // Found a non-conflicting slot - update candidate time slots tracking
+            usedCandidateTimeSlots.push(proposedSlot);
+            
             const interviewer = users?.find((user: any) => user.id === interviewerId);
             const interviewerName = interviewer ? `${interviewer.name} (${interviewer.email})` : `Interviewer ${interviewerId.substring(0, 8)}`;
             
@@ -228,7 +229,6 @@ export class SchedulerService {
               interviewer_name: interviewerName
             });
             
-            foundNonConflictingSlot = true;
             break;
           }
         }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,6 @@ export interface User {
   name: string;
   email: string;
   role: 'candidate' | 'interviewer';
-  timezone?: string; // Optional timezone from most recent availability record
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adopts scheduler timezone across UI and scheduling, migrates availability to store time slots + timezone, removes user timezone, and improves scheduling with 30-minute buffers and conflict-free multi-interviewer handling.
> 
> - **Backend**:
>   - **Database Schema**: `availability` now stores `time_slots` (with dates) and `timezone`; adds DATETIME timestamps; migration added; removes `users.timezone` column and related code.
>   - **Scheduling Logic (`SchedulerService`)**:
>     - Increases default `bufferTime` to 30 minutes and prevents candidate double-booking across interviews.
>     - Uses scheduler `timezone` for `scheduled_time` creation and messages; converts to UTC via `zonedTimeToUtc`.
>     - Returns all overlapping slots (not just best); improves multi-interviewer scheduling and messaging.
>   - **Routes**:
>     - `/scheduler/:id/users` response no longer includes per-user `timezone`.
>     - `/scheduler/:id/status` groups slots by `date`, converts display times using provided timezone; reduces noisy logs.
> - **Frontend**:
>   - Displays scheduled dates/times using scheduler `timezone` (e.g., in `showDetailedSchedule` and scheduled results card).
>   - Removes timezone selector from `index.html` and stops setting user timezone on registration.
>   - Formats individual interview rows using scheduler `timezone`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc440998edbd03e45fed551289900e94e54a92ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->